### PR TITLE
Fix SpeedControlPageOutput#finish() calls pageOutput.finish() twice

### DIFF
--- a/src/main/java/org/embulk/filter/SpeedometerFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/SpeedometerFilterPlugin.java
@@ -123,7 +123,6 @@ public class SpeedometerFilterPlugin
         @Override
         public void finish() {
             pageBuilder.finish();
-            pageOutput.finish();
         }
 
         @Override

--- a/src/test/java/org/embulk/filter/TestSpeedometerFilterPlugin.java
+++ b/src/test/java/org/embulk/filter/TestSpeedometerFilterPlugin.java
@@ -91,7 +91,6 @@ public class TestSpeedometerFilterPlugin
         new Verifications() {{
             taskSource.loadTask(PluginTask.class); times = 1;
             builder.finish(); times = 1;
-            inPageOutput.finish(); times = 1;
         }};
     }
 


### PR DESCRIPTION
SpeedControlPageOutput#finish() calls pageOutput.finish() twice. Because pageBuilder.finish() method also calls pageOutput.finish(). 

To avoid unexpected side-effect, pageOutput.finish method call should be removed within SpeedControlPageOutput#finish method.
