### PR TITLE
Fixed the issue to call PageOutput.close() twice

### DIFF
--- a/src/main/java/org/embulk/filter/SpeedometerFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/SpeedometerFilterPlugin.java
@@ -89,7 +89,6 @@ public class SpeedometerFilterPlugin
         private final SpeedometerSpeedController controller;
         private final Schema schema;
         private final TimestampFormatter[] timestampFormatters;
-        private final PageOutput pageOutput;
         private final PageReader pageReader;
         private final BufferAllocator allocator;
         private final int delimiterLength;
@@ -99,7 +98,6 @@ public class SpeedometerFilterPlugin
         SpeedControlPageOutput(PluginTask task, Schema schema, PageOutput pageOutput) {
             this.controller = new SpeedometerSpeedController(task, SpeedometerSpeedAggregator.getInstance());
             this.schema = schema;
-            this.pageOutput = pageOutput;
             this.allocator = task.getBufferAllocator();
             this.delimiterLength = task.getDelimiter().length();
             this.recordPaddingSize = task.getRecordPaddingSize();
@@ -130,7 +128,6 @@ public class SpeedometerFilterPlugin
             controller.stop();
             pageBuilder.close();
             pageReader.close();
-            pageOutput.close();
         }
 
         class ColumnVisitorImpl implements ColumnVisitor {

--- a/src/test/java/org/embulk/filter/TestSpeedometerFilterPlugin.java
+++ b/src/test/java/org/embulk/filter/TestSpeedometerFilterPlugin.java
@@ -109,7 +109,6 @@ public class TestSpeedometerFilterPlugin
             taskSource.loadTask(PluginTask.class); times = 1;
             builder.close(); times = 1;
             reader.close(); times = 1;
-            inPageOutput.close(); times = 1;
         }};
     }
 }


### PR DESCRIPTION
PageBuilder.close() calls PageOutput.close(). However,
this plugin also calls PageOutput.close() after PageBuilder.close()
is called. So, this change removes PageOutput.close() to avoid
it is called twice.
